### PR TITLE
changes to new image names

### DIFF
--- a/lamp.yaml
+++ b/lamp.yaml
@@ -39,11 +39,11 @@ parameters:
       Required: Server image used for all servers that are created as a part of
       this deployment.
     type: string
-    default: CentOS 6.5 (PVHVM)
+    default: CentOS 6 (PVHVM)
     constraints:
     - allowed_values:
-      - CentOS 6.5 (PVHVM)
-      - Red Hat Enterprise Linux 6.6 (PVHVM)
+      - CentOS 6 (PVHVM)
+      - Red Hat Enterprise Linux 6 (PVHVM)
       - Ubuntu 14.04 LTS (Trusty Tahr) (PVHVM)
       - Ubuntu 12.04 LTS (Precise Pangolin) (PVHVM)
       - Debian 7 (Wheezy) (PVHVM)


### PR DESCRIPTION
DO NOT MERGE YET

This will allow compatibility with the new image names being released today. They are not live yet so the launch will need to be coordinated with the images team.