### PR TITLE
Added support for firewalld

### DIFF
--- a/site-cookbooks/LAMP/files/default/lamp/roles/apache2/tasks/firewall.yml
+++ b/site-cookbooks/LAMP/files/default/lamp/roles/apache2/tasks/firewall.yml
@@ -1,12 +1,21 @@
 ---
-- name: Setup default apache firewall rules - RedHat
+- name: Setup default apache firewall rules - RedHat 6
   command: "/sbin/iptables -I INPUT 2 -p tcp --dport {{ item }} -j ACCEPT"
   with_items: open_firewall_ports
-  when: ansible_os_family == 'RedHat'
+  when: ansible_os_family == 'RedHat' and ansible_distribution_major_version == '6'
 
-- name: Save default apache firewall rules - RedHat
-  command: "/sbin/service iptables save"
-  when: ansible_os_family == 'RedHat'
+- name: Save default apache firewall rules - RedHat 6
+  command: '/sbin/service iptables save'
+  when: ansible_os_family == 'RedHat' and ansible_distribution_major_version == '6'
+
+- name: Setup default apache firewall rules - RedHat 7
+  firewalld: port={{ item }}/tcp permanent=yes state=enabled
+  with_items: open_firewall_ports
+  when: ansible_os_family == 'RedHat' and ansible_distribution_major_version == '7'
+
+- name: Save default apache firewall rules - RedHat 7
+  command: '/usr/bin/firewall-cmd --reload'
+  when: ansible_os_family == 'RedHat' and ansible_distribution_major_version == '7'
 
 - name: Setup default apache firewall rules - Debian
   command: ufw allow {{ item }}


### PR DESCRIPTION
The existing playbook doesn't play nice with firewalld. Due to the fact the iptables isn't a service in RHEL/CentOS7, none of the rules added by the `firewall.yml` task are persistent.
I've added a bit of a workaround for now, but this should be revisited.
I should mention that the manual reload won't be needed once ansible 1.9 becomes available in pypi, since that supports `immediate=yes` for the `firewalld` module, which kicks off a reload as well.