### PR TITLE
Added necessary InlcudeOptional to bring in vhost configs

### DIFF
--- a/site-cookbooks/LAMP/files/default/lamp/roles/apache2/templates/RedHat/v24/httpd.conf.j2
+++ b/site-cookbooks/LAMP/files/default/lamp/roles/apache2/templates/RedHat/v24/httpd.conf.j2
@@ -449,4 +449,3 @@ AddDefaultCharset UTF-8
 # Load config files in the "/etc/httpd/conf.d" directory, if any.
 IncludeOptional conf.d/*.conf
 IncludeOptional vhost.d/*.conf
-

--- a/site-cookbooks/LAMP/files/default/lamp/roles/apache2/templates/RedHat/v24/httpd.conf.j2
+++ b/site-cookbooks/LAMP/files/default/lamp/roles/apache2/templates/RedHat/v24/httpd.conf.j2
@@ -448,3 +448,5 @@ AddDefaultCharset UTF-8
 #
 # Load config files in the "/etc/httpd/conf.d" directory, if any.
 IncludeOptional conf.d/*.conf
+IncludeOptional vhost.d/*.conf
+


### PR DESCRIPTION
This is missing from the v24 config for Apache2 and RedHat and brings it in line with v22.