### PR TITLE
Adds holland alerts for managed cloud/operations customers

### DIFF
--- a/site-cookbooks/LAMP/files/default/lamp/group_vars/all
+++ b/site-cookbooks/LAMP/files/default/lamp/group_vars/all
@@ -86,4 +86,5 @@
 'holland_version': '1.0.10-2'
 'holland_dir': '/var/lib/mysqlbackup'
 'holland_password': "{{ lookup('password', '/tmp/holland_' + ansible_hostname + '-' + ansible_date_time.time) }}"
-
+'notification_plan': 'npManaged'
+### Notification plan will need to be specified and changed once infrastructure gets monitoring

--- a/site-cookbooks/LAMP/files/default/lamp/roles/holland/handlers/main.yml
+++ b/site-cookbooks/LAMP/files/default/lamp/roles/holland/handlers/main.yml
@@ -1,0 +1,8 @@
+---
+- stat: path=/usr/bin/rackspace-monitoring-agent
+  register: p
+
+- name: restart rackspace-monitoring-agent
+  service: name='rackspace-monitoring-agent' state=restarted
+  when: p.stat.exists
+

--- a/site-cookbooks/LAMP/files/default/lamp/roles/holland/tasks/default.yml
+++ b/site-cookbooks/LAMP/files/default/lamp/roles/holland/tasks/default.yml
@@ -29,5 +29,13 @@
 - name: Create RS monitoring plugin folder
   file: dest=/usr/lib/rackspace-monitoring-agent/plugins state=directory
 
+- name: Check /etc/rackspace-monitoring-agent.conf.d/
+  file: dest=/etc/rackspace-monitoring-agent.conf.d/ state=directory owner=root group=root
 
+- stat: path=/usr/bin/rackspace-monitoring-agent
+  register: p
 
+- name: Copy holland_mysqldump.yaml
+  template: src=holland_mysqldump.yaml.j2 dest=/etc/rackspace-monitoring-agent.conf.d/holland_mysqldump.yaml
+  notify: restart rackspace-monitoring-agent
+  when: p.stat.exists

--- a/site-cookbooks/LAMP/files/default/lamp/roles/holland/templates/holland_mysqldump.yaml.j2
+++ b/site-cookbooks/LAMP/files/default/lamp/roles/holland/templates/holland_mysqldump.yaml.j2
@@ -1,0 +1,28 @@
+type        : agent.plugin
+label       : '[AGENT] Holland mysqldump'
+disabled    : false
+period      : 60
+timeout     : 30
+details     :
+    file    : holland_mysqldump.py
+alarms      :
+    alarm1  :
+        label                 : '[AGENT] Holland mysqldump'
+        notification_plan_id  : {{notification_plan}} 
+        criteria              : |
+          if (metric['sql_ping_succeeds'] == 'false') { 
+            return new AlarmStatus(CRITICAL, 'holland-plugin: MySQL is not running.'); 
+          } 
+          if (metric['sql_creds_exist'] == 'false') { 
+            return new AlarmStatus(CRITICAL, 'holland-plugin: MySQL credentials file does not exist.'); 
+          } 
+          if (metric['sql_status_succeeds'] == 'false') { 
+            return new AlarmStatus(CRITICAL, 'holland-plugin: MySQL credentials do not authenticate.'); 
+          } 
+          if (metric['dump_age'] > 172800) { 
+            return new AlarmStatus(CRITICAL, 'holland-plugin: mysqldump file is older than 2d.'); 
+          } 
+          if (metric['error_count'] > 0) { 
+            return new AlarmStatus(CRITICAL, 'holland-plugin: #{last_error}.'); 
+          } 
+          return new AlarmStatus(OK, 'holland-plugin: MySQL and Holland OK'); 


### PR DESCRIPTION
This will have the Holland alert automatically created for managed operations/cloud customers. When the agent comes standard with new builds, additional work will need to be done to ensure the correct plan is used based on service level.