### PR TITLE
Fixes #53

### DIFF
--- a/site-cookbooks/LAMP/files/default/lamp/roles/holland/tasks/default.yml
+++ b/site-cookbooks/LAMP/files/default/lamp/roles/holland/tasks/default.yml
@@ -39,3 +39,13 @@
   template: src=holland_mysqldump.yaml.j2 dest=/etc/rackspace-monitoring-agent.conf.d/holland_mysqldump.yaml
   notify: restart rackspace-monitoring-agent
   when: p.stat.exists
+
+- name: Download holland_mysqldump.py 
+  get_url:
+    url: https://raw.githubusercontent.com/racker/rackspace-monitoring-agent-plugins-contrib/master/holland_mysqldump.py
+    dest: /usr/lib/rackspace-monitoring-agent/plugins/holland_mysqldump.py
+    mode: 0744
+    owner: root
+    group: root
+  notify: restart rackspace-monitoring-agent
+  when: p.stat.exists

--- a/site-cookbooks/LAMP/files/default/lamp/roles/holland/tasks/mysqldump.yml
+++ b/site-cookbooks/LAMP/files/default/lamp/roles/holland/tasks/mysqldump.yml
@@ -41,3 +41,5 @@
 - name: Add cron job
   template: src=holland.cron.j2 dest=/etc/cron.d/holland
 
+- name: Run Holland
+  command: /usr/sbin/holland bk


### PR DESCRIPTION
Adds an initial run and the monitoring plugin so the create check doesn't immediately make an error