### PR TITLE
updates template to remove Holland mysql checks in favor of independent mysql checks

### DIFF
--- a/site-cookbooks/LAMP/files/default/lamp/roles/holland/templates/holland_mysqldump.yaml.j2
+++ b/site-cookbooks/LAMP/files/default/lamp/roles/holland/templates/holland_mysqldump.yaml.j2
@@ -10,15 +10,6 @@ alarms      :
         label                 : '[AGENT] Holland mysqldump'
         notification_plan_id  : {{notification_plan}} 
         criteria              : |
-          if (metric['sql_ping_succeeds'] == 'false') { 
-            return new AlarmStatus(CRITICAL, 'holland-plugin: MySQL is not running.'); 
-          } 
-          if (metric['sql_creds_exist'] == 'false') { 
-            return new AlarmStatus(CRITICAL, 'holland-plugin: MySQL credentials file does not exist.'); 
-          } 
-          if (metric['sql_status_succeeds'] == 'false') { 
-            return new AlarmStatus(CRITICAL, 'holland-plugin: MySQL credentials do not authenticate.'); 
-          } 
           if (metric['dump_age'] > 172800) { 
             return new AlarmStatus(CRITICAL, 'holland-plugin: mysqldump file is older than 2d.'); 
           } 


### PR DESCRIPTION
The holland plugin was doing independent mysql monitoring in an attempt to be end-to-end. https://github.com/racker/rackspace-monitoring-agent-plugins-contrib/pull/84 will adjust this so that Holland is just taking care of itself, and a MySQL check can be set up without triggering duplicate alerts.