### PR TITLE
fixes issue #73

### DIFF
--- a/site-cookbooks/LAMP/files/default/lamp/roles/holland/templates/backupsets/default.conf.j2
+++ b/site-cookbooks/LAMP/files/default/lamp/roles/holland/templates/backupsets/default.conf.j2
@@ -41,6 +41,6 @@ options = "--rsyncable"
 # define holland user information
 
 user = holland
-password = '{{holland_password}}'
+password = {{holland_password}}
 host = localhost
 port = 3306

--- a/site-cookbooks/LAMP/files/default/lamp/roles/holland/templates/holland_mysqldump.yaml.j2
+++ b/site-cookbooks/LAMP/files/default/lamp/roles/holland/templates/holland_mysqldump.yaml.j2
@@ -10,6 +10,14 @@ alarms      :
         label                 : '[AGENT] Holland mysqldump'
         notification_plan_id  : {{notification_plan}} 
         criteria              : |
+          if (metric['sql_creds_exist'] == 'false') {
+            return new AlarmStatus(CRITICAL, 'holland-plugin: MySQL credentials file \
+                    does not exist.');
+          }
+          if (metric['sql_status_succeeds'] == 'false') {
+            return new AlarmStatus(CRITICAL, 'holland-plugin: MySQL credentials do \
+                    not authenticate.');
+          }
           if (metric['dump_age'] > 172800) { 
             return new AlarmStatus(CRITICAL, 'holland-plugin: mysqldump file is older than 2d.'); 
           } 


### PR DESCRIPTION
This should fix the issues we've been having with monitoring alerts. This passed my hot tests locally, but we've been having some unrelated failures due to yum not removing dependencies for mysql 5.1 properly. A retry fixes those if they happen.