### PR TITLE
Remove CentOS as these images are no longer working

### DIFF
--- a/lamp.yaml
+++ b/lamp.yaml
@@ -41,11 +41,9 @@ parameters:
       Required: Server image used for all servers that are created as a part of
       this deployment.
     type: string
-    default: CentOS 6 (PVHVM)
+    default: Debian 8 (Jessie) (PVHVM)
     constraints:
     - allowed_values:
-      - CentOS 7 (PVHVM)
-      - CentOS 6 (PVHVM)
       - Debian 8 (Jessie) (PVHVM)
       - Debian 7 (Wheezy) (PVHVM)
       - Red Hat Enterprise Linux 6 (PVHVM)

--- a/tests.yaml
+++ b/tests.yaml
@@ -118,27 +118,3 @@ test-cases:
             disable_known_hosts: True
             use_ssh_config: True
             fabfile: test/fabric/lamp.py
-
-- name: Debian 8
-  create:
-    parameters:
-      image: Debian 8 (Jessie) (PVHVM)
-    timeout: 45
-  resource_tests:
-    ssh_private_key: { get_output: private_key }
-    ssh_key_file: tmp/private_key
-    tests:
-    - lamp:
-        fabric:
-          env:
-            user: root
-            key_filename: tmp/private_key
-            hosts: { get_output: server_ip }
-            tasks:
-              - artifacts
-              - check
-            abort_on_prompts: True
-            connection_attempts: 3
-            disable_known_hosts: True
-            use_ssh_config: True
-            fabfile: test/fabric/lamp.py


### PR DESCRIPTION
The CentOS images are breaking with some yum conflict with managed automation. Removing those options while a more permanent fix is developed.