### PR TITLE
changes holland to use Heat password, not generate it's own with Ansible

### DIFF
--- a/site-cookbooks/LAMP/files/default/lamp/group_vars/all
+++ b/site-cookbooks/LAMP/files/default/lamp/group_vars/all
@@ -85,6 +85,5 @@
 ### HOLLAND VARS
 'holland_version': '1.0.10-2'
 'holland_dir': '/var/lib/mysqlbackup'
-'holland_password': "{{ lookup('password', '/tmp/holland_' + ansible_hostname + '-' + ansible_date_time.time) }}"
 'notification_plan': 'npManaged'
 ### Notification plan will need to be specified and changed once infrastructure gets monitoring

--- a/site-cookbooks/LAMP/files/default/lamp/roles/holland/tasks/mysqldump.yml
+++ b/site-cookbooks/LAMP/files/default/lamp/roles/holland/tasks/mysqldump.yml
@@ -33,7 +33,7 @@
   template: src=backupsets/default.conf.j2 dest=/etc/holland/backupsets/default.conf
 
 - name: Add holland MySQL user
-  mysql_user: name=holland host=localhost password="{{holland_password}}" priv=*.*:ALL
+  mysql_user: name=holland host=localhost password="{{mysql_password}}" priv=*.*:ALL
 
 - name: Flush privileges
   shell: mysqladmin -u root flush-privileges

--- a/site-cookbooks/LAMP/files/default/lamp/roles/holland/templates/backupsets/default.conf.j2
+++ b/site-cookbooks/LAMP/files/default/lamp/roles/holland/templates/backupsets/default.conf.j2
@@ -41,6 +41,6 @@ options = "--rsyncable"
 # define holland user information
 
 user = holland
-password = {{holland_password}}
+password = {{mysql_password}}
 host = localhost
 port = 3306


### PR DESCRIPTION
This should fix the issues with LAMP creating it's own password for holland with illegal charachters like ','