### PR TITLE
Switch PHP version for RHEL6 due to EOL

### DIFF
--- a/site-cookbooks/LAMP/files/default/lamp/group_vars/RedHat
+++ b/site-cookbooks/LAMP/files/default/lamp/group_vars/RedHat
@@ -32,12 +32,12 @@
 'php_ini': "/etc/php.ini"
 'apache': "httpd"
 'packages': [
-                "php54",
-                "php54-gd",
-                "php54-mysql",
-                "php54-pecl-apc",
-                "php54-xml",
-                "php54-devel"
+                "php56u",
+                "php56u-gd",
+                "php56u-mysql",
+                "php56u-opcache",
+                "php56u-xml",
+                "php56u-devel"
                 ]
 'session_save_path': "/var/lib/php/session"
 
@@ -50,7 +50,7 @@
 # PHP-FPM VARS
 'php_fpm': 'php-fpm'
 'php_fpm_path': '/etc/php-fpm.d'
-'php_fpm_pkgs': [ 'php54-fpm', 'php54-pecl-apc' ]
+'php_fpm_pkgs': [ 'php56u-fpm', 'php56u-opcache' ]
 
 
 # MYSQL VARS

--- a/site-cookbooks/LAMP/files/default/lamp/roles/mysql/tasks/client.yml
+++ b/site-cookbooks/LAMP/files/default/lamp/roles/mysql/tasks/client.yml
@@ -26,9 +26,9 @@
   command: rpm -e --nodeps mysql-libs
   when: if_found is defined and if_found.rc == 0 
 
-#- name: Remove mysql from Redhat base 5
-#  yum: name=mysql state=absent
-#  when: ansible_os_family == 'RedHat' and ansible_distribution_major_version|int < 6
+- name: Remove mysql client from Redhat base 5
+  yum: name=mysql state=absent
+  when: ansible_os_family == 'RedHat' and ansible_distribution_major_version|int < 6
 
 - name: Install MySQL packages on Redhat base
   yum: name={{item}} state=latest

--- a/site-cookbooks/LAMP/files/default/lamp/roles/mysql/tasks/client.yml
+++ b/site-cookbooks/LAMP/files/default/lamp/roles/mysql/tasks/client.yml
@@ -26,9 +26,19 @@
   command: rpm -e --nodeps mysql-libs
   when: if_found is defined and if_found.rc == 0 
 
-- name: Remove mysql client from Redhat base 5
-  yum: name=mysql state=absent
-  when: ansible_os_family == 'RedHat' and ansible_distribution_major_version|int < 6
+- name: Determine if mysql client package exist on Redhat system base version 5
+  command: /bin/rpm -q mysql
+  register: mysql-client_found
+  when: ansible_os_family == 'RedHat' and ansible_distribution_major_version == '5'
+  ignore_errors: yes
+
+- name: Erase mysql client with no deps
+  command: rpm -e --nodeps mysql
+  when: mysql-client_found is defined and mysql-client_found.rc == 0
+
+#- name: Remove mysql client from Redhat base 5
+#  yum: name=mysql state=absent
+#  when: ansible_os_family == 'RedHat' and ansible_distribution_major_version|int < 6
 
 - name: Install MySQL packages on Redhat base
   yum: name={{item}} state=latest

--- a/site-cookbooks/LAMP/files/default/lamp/roles/mysql/tasks/client.yml
+++ b/site-cookbooks/LAMP/files/default/lamp/roles/mysql/tasks/client.yml
@@ -37,3 +37,4 @@
   - "{{mysqlpkg_devel}}"
   when: ansible_os_family == 'RedHat'
   ignore_errors: yes
+

--- a/site-cookbooks/LAMP/files/default/lamp/roles/mysql/tasks/client.yml
+++ b/site-cookbooks/LAMP/files/default/lamp/roles/mysql/tasks/client.yml
@@ -26,17 +26,7 @@
   command: rpm -e --nodeps mysql-libs
   when: if_found is defined and if_found.rc == 0 
 
-- name: Determine if mysql client package exist on Redhat system base version 5
-  command: /bin/rpm -q mysql
-  register: mysql-client_found
-  when: ansible_os_family == 'RedHat' and ansible_distribution_major_version == '5'
-  ignore_errors: yes
-
-- name: Erase mysql client with no deps
-  command: rpm -e --nodeps mysql
-  when: mysql-client_found is defined and mysql-client_found.rc == 0
-
-#- name: Remove mysql client from Redhat base 5
+#- name: Remove mysql from Redhat base 5
 #  yum: name=mysql state=absent
 #  when: ansible_os_family == 'RedHat' and ansible_distribution_major_version|int < 6
 
@@ -47,4 +37,3 @@
   - "{{mysqlpkg_devel}}"
   when: ansible_os_family == 'RedHat'
   ignore_errors: yes
-


### PR DESCRIPTION
PHP54 is EOL as of 2015-09-14. We were notified that Monday Oct 12 PHP54 will be removed from the IUS repositories.
Using PHP56 for RHEL 6 since it will be EOL until 2017-08-28

RHEL5 is still all sorts of broken and using PHP54