### PR TITLE
Passwordfix

### DIFF
--- a/site-cookbooks/LAMP/files/default/lamp/group_vars/RHEL_7.yml
+++ b/site-cookbooks/LAMP/files/default/lamp/group_vars/RHEL_7.yml
@@ -11,7 +11,7 @@
                 "php56u",
                 "php56u-opcache",
                 "php56u-gd",
-                "php56u-mysql",
+                "php56u-mysqlnd",
                 "php56u-xml",
                 "php56u-devel"
                 ]

--- a/site-cookbooks/LAMP/files/default/lamp/group_vars/RedHat
+++ b/site-cookbooks/LAMP/files/default/lamp/group_vars/RedHat
@@ -32,12 +32,12 @@
 'php_ini': "/etc/php.ini"
 'apache': "httpd"
 'packages': [
-                "php54",
-                "php54-gd",
-                "php54-mysql",
-                "php54-pecl-apc",
-                "php54-xml",
-                "php54-devel"
+                "php56u",
+                "php56u-opcache",
+                "php56u-gd",
+                "php56u-mysqlnd",
+                "php56u-xml",
+                "php56u-devel"
                 ]
 'session_save_path': "/var/lib/php/session"
 
@@ -50,7 +50,7 @@
 # PHP-FPM VARS
 'php_fpm': 'php-fpm'
 'php_fpm_path': '/etc/php-fpm.d'
-'php_fpm_pkgs': [ 'php54-fpm', 'php54-pecl-apc' ]
+'php_fpm_pkgs': [ 'php56u-fpm', 'php56u-opcache' ]
 
 
 # MYSQL VARS

--- a/site-cookbooks/LAMP/files/default/lamp/group_vars/all
+++ b/site-cookbooks/LAMP/files/default/lamp/group_vars/all
@@ -56,7 +56,7 @@
 
 
 ### MYSQL VARS
-'mysql_password': "{{ lookup('password', '/tmp/mysql_' + ansible_hostname + '-' + ansible_date_time.time + ' chars=ascii_letters,digits') }}"
+'mysql_password': "{{ lookup('password', '/tmp/' + ansible_hostname + '-' + ansible_date_time.time + '/mysql chars=ascii_letters,digits') }}"
 
 'datadir': '/var/lib/mysql'
 'log_slow': '/var/lib/mysql/slow-log'
@@ -78,13 +78,13 @@
 
 ### PHPMYADMIN VARS
 'htuser': 'serverinfo'
-'htpass': "{{ lookup('password', '/tmp/htpass_' + ansible_hostname + '-' + ansible_date_time.time + ' chars=ascii_letters,digits') }}"
-'blowfish_pass': "{{ lookup('password', '/tmp/blowfish_' + ansible_hostname + '-' + ansible_date_time.time + ' chars=ascii_letters,digits') }}"
+'htpass': "{{ lookup('password', '/tmp/' + ansible_hostname + '-' + ansible_date_time.time + '/htpass chars=ascii_letters,digits') }}"
+'blowfish_pass': "{{ lookup('password', '/tmp/' + ansible_hostname + '-' + ansible_date_time.time + '/blowfish chars=ascii_letters,digits') }}"
 
 
 ### HOLLAND VARS
 'holland_version': '1.0.10-2'
 'holland_dir': '/var/lib/mysqlbackup'
-'holland_password': "{{ lookup('password', '/tmp/holland_' + ansible_hostname + '-' + ansible_date_time.time) }}"
+'holland_password': "{{ lookup('password', '/tmp/' + ansible_hostname + '-' + ansible_date_time.time) + '/holland chars=ascii_letters,digits'}}"
 'notification_plan': 'npManaged'
 ### Notification plan will need to be specified and changed once infrastructure gets monitoring

--- a/site-cookbooks/LAMP/files/default/lamp/group_vars/all
+++ b/site-cookbooks/LAMP/files/default/lamp/group_vars/all
@@ -56,7 +56,7 @@
 
 
 ### MYSQL VARS
-'mysql_password': "{{ lookup('password', '/tmp/' + ansible_hostname + '-' + ansible_date_time.time + '/mysql chars=ascii_letters,digits') }}"
+'mysql_password': "{{ lookup('password', '/tmp/' + ansible_hostname + '-' + ansible_date_time.time + '-mysql chars=ascii_letters,digits') }}"
 
 'datadir': '/var/lib/mysql'
 'log_slow': '/var/lib/mysql/slow-log'
@@ -78,13 +78,13 @@
 
 ### PHPMYADMIN VARS
 'htuser': 'serverinfo'
-'htpass': "{{ lookup('password', '/tmp/' + ansible_hostname + '-' + ansible_date_time.time + '/htpass chars=ascii_letters,digits') }}"
-'blowfish_pass': "{{ lookup('password', '/tmp/' + ansible_hostname + '-' + ansible_date_time.time + '/blowfish chars=ascii_letters,digits') }}"
+'htpass': "{{ lookup('password', '/tmp/' + ansible_hostname + '-' + ansible_date_time.time + '-htpass chars=ascii_letters,digits') }}"
+'blowfish_pass': "{{ lookup('password', '/tmp/' + ansible_hostname + '-' + ansible_date_time.time + '-blowfish chars=ascii_letters,digits') }}"
 
 
 ### HOLLAND VARS
 'holland_version': '1.0.10-2'
 'holland_dir': '/var/lib/mysqlbackup'
-'holland_password': "{{ lookup('password', '/tmp/' + ansible_hostname + '-' + ansible_date_time.time) + '/holland chars=ascii_letters,digits'}}"
+'holland_password': "{{ lookup('password', '/tmp/' + ansible_hostname + '-' + ansible_date_time.time) + '-holland chars=ascii_letters,digits'}}"
 'notification_plan': 'npManaged'
 ### Notification plan will need to be specified and changed once infrastructure gets monitoring

--- a/site-cookbooks/LAMP/files/default/lamp/group_vars/all
+++ b/site-cookbooks/LAMP/files/default/lamp/group_vars/all
@@ -56,7 +56,7 @@
 
 
 ### MYSQL VARS
-'mysql_password': "{{ lookup('password', '/tmp/mysql_' + ansible_hostname + '-' + ansible_date_time.time) }}"
+'mysql_password': "{{ lookup('password', '/tmp/mysql_' + ansible_hostname + '-' + ansible_date_time.time + ' chars=ascii_letters,digits') }}"
 
 'datadir': '/var/lib/mysql'
 'log_slow': '/var/lib/mysql/slow-log'
@@ -78,8 +78,8 @@
 
 ### PHPMYADMIN VARS
 'htuser': 'serverinfo'
-'htpass': "{{ lookup('password', '/tmp/htpass_' + ansible_hostname + '-' + ansible_date_time.time) }}"
-'blowfish_pass': "{{ lookup('password', '/tmp/blowfish_' + ansible_hostname + '-' + ansible_date_time.time) }}"
+'htpass': "{{ lookup('password', '/tmp/htpass_' + ansible_hostname + '-' + ansible_date_time.time + ' chars=ascii_letters,digits') }}"
+'blowfish_pass': "{{ lookup('password', '/tmp/blowfish_' + ansible_hostname + '-' + ansible_date_time.time + ' chars=ascii_letters,digits') }}"
 
 
 ### HOLLAND VARS

--- a/site-cookbooks/LAMP/files/default/lamp/group_vars/all
+++ b/site-cookbooks/LAMP/files/default/lamp/group_vars/all
@@ -85,6 +85,6 @@
 ### HOLLAND VARS
 'holland_version': '1.0.10-2'
 'holland_dir': '/var/lib/mysqlbackup'
-'holland_password': "{{ lookup('password', '/tmp/' + ansible_hostname + '-' + ansible_date_time.time) + '-holland chars=ascii_letters,digits'}}"
+'holland_password': "{{ lookup('password', '/tmp/' + ansible_hostname + '-' + ansible_date_time.time + '-holland chars=ascii_letters,digits') }}"
 'notification_plan': 'npManaged'
 ### Notification plan will need to be specified and changed once infrastructure gets monitoring


### PR DESCRIPTION
Passed my local testing. Changes the password format when run outside of heat to have safer passwords. Also fixes a bug in the RHEL playbooks where it was still using 54 in some cases and a missing package in another.