### PR TITLE
attempts to correct nginx repository change

### DIFF
--- a/site-cookbooks/LAMP/files/default/lamp/roles/nginx/templates/RedHat.repo.j2
+++ b/site-cookbooks/LAMP/files/default/lamp/roles/nginx/templates/RedHat.repo.j2
@@ -1,5 +1,9 @@
 [nginx]
 name=nginx repo
+{% if ansible_distribution|lower == 'redhat' %}
 baseurl=http://nginx.org/packages/{{ ansible_distribution|lower }}/{{ ansible_distribution_major_version }}/x86_64/
+{% else %}
+baseurl=http://nginx.org/packages/{{ ansible_distribution|lower }}/{{ ansible_distribution_major_version }}/x86_64/
+{% endif %}
 gpgcheck=0
 enabled=1


### PR DESCRIPTION
Nginx changed their repo structure to use 'rhel' instead of 'redhat'. This change just codes that in for Nginx. This is not used by the lamp deployment directly, but it's support functionality.