### PR TITLE
Include modules before testing for them

### DIFF
--- a/site-cookbooks/LAMP/files/default/lamp/roles/apache2/templates/RedHat/v24/httpd.conf.j2
+++ b/site-cookbooks/LAMP/files/default/lamp/roles/apache2/templates/RedHat/v24/httpd.conf.j2
@@ -69,6 +69,8 @@ KeepAliveTimeout {{ keep_alive_timeout }}
 ## Server-Pool Size Regulation (MPM specific)
 ##
 
+Include conf.modules.d/*.conf
+
 # prefork MPM
 # StartServers: number of server processes to start
 # MinSpareServers: minimum number of server processes which are kept spare
@@ -114,7 +116,6 @@ KeepAliveTimeout {{ keep_alive_timeout }}
 # Example:
 # LoadModule foo_module modules/mod_foo.so
 #
-Include conf.modules.d/*.conf
 
 #
 # If you wish httpd to run as a different user or group, you must run


### PR DESCRIPTION
We can't test for the prefork module before it's loaded with the "Include conf.modules.d/*.conf" line